### PR TITLE
CR: Update colour of the bar when maelstrom weapon reach 10

### DIFF
--- a/Bars/Abstract/Bar.lua
+++ b/Bars/Abstract/Bar.lua
@@ -1286,6 +1286,7 @@ function BarMixin:UpdateFragmentedPowerDisplay(layoutName, data, maxPower)
         local auraData = C_UnitAuras.GetPlayerAuraBySpellID(344179) -- Maelstrom Weapon
         local current = auraData and auraData.applications or 0
         local above5MwColor = addonTable:GetOverrideResourceColor("MAELSTROM_WEAPON_ABOVE_5") or color
+        local mW10Color = addonTable:GetOverrideResourceColor("MAELSTROM_WEAPON_10") or color
 
         -- Reuse pre-allocated table for performance
         local displayOrder = self._displayOrder
@@ -1317,12 +1318,16 @@ function BarMixin:UpdateFragmentedPowerDisplay(layoutName, data, maxPower)
 
                 mwFrame:SetMinMaxValues(0, 1)
 
-                if idx <= current then
+                 if idx <= current then
                     mwFrame:SetValue(1, data.smoothProgress and Enum.StatusBarInterpolation.ExponentialEaseOut or nil)
-                    if current > 5 and idx <= math.fmod(current - 1, 5) + 1 then
-                        mwFrame:SetStatusBarColor(above5MwColor.r, above5MwColor.g, above5MwColor.b, above5MwColor.a or 1)
-                    else
-                        mwFrame:SetStatusBarColor(color.r, color.g, color.b, color.a or 1)
+                    if current == 10 then
+                        mwFrame:SetStatusBarColor(mW10Color.r, mW10Color.g, mW10Color.b, mW10Color.a or 1)
+                    else 
+                        if current > 5 and idx <= math.fmod(current - 1, 5) + 1 then
+                            mwFrame:SetStatusBarColor(above5MwColor.r, above5MwColor.g, above5MwColor.b, above5MwColor.a or 1)
+                        else
+                            mwFrame:SetStatusBarColor(color.r, color.g, color.b, color.a or 1)
+                        end
                     end
                 else
                     mwFrame:SetValue(0, data.smoothProgress and Enum.StatusBarInterpolation.ExponentialEaseOut or nil)

--- a/Helpers/Color.lua
+++ b/Helpers/Color.lua
@@ -120,6 +120,8 @@ function addonTable:GetResourceColor(resource)
         color = { r = 0, g = 0.5, b = 1 }
     elseif resource == "MAELSTROM_WEAPON_ABOVE_5" then
         color = { r = 1, g = 0.5, b = 0 }
+    elseif resource == "MAELSTROM_WEAPON_10" then
+        color = { r = 1, g = 0.5, b = 1 }
     elseif resource == "TIP_OF_THE_SPEAR" then
         color = { r = 0.6, g = 0.8, b = 0.2 }
     elseif resource == "WHIRLWIND" then

--- a/Settings/HealthAndPowerColorSettings.lua
+++ b/Settings/HealthAndPowerColorSettings.lua
@@ -64,6 +64,10 @@ local PowerData = {
         label = L["MAELSTROM_WEAPON"] .. ' > 5',
         key = "MAELSTROM_WEAPON_ABOVE_5",
     },
+     {
+        label = L["MAELSTROM_WEAPON"] .. ' == 10',
+        key = "MAELSTROM_WEAPON_10",
+    },
     {
         label = L["INSANITY"],
         key = Enum.PowerType.Insanity,


### PR DESCRIPTION
Hi, I thought it would be useful to have the colour update to something else when the maelstrom weapon stacks reach 10. Its very useful for me. Hope this is fine. We can change the colour to something else if you want. This is my first time updating an addon, I have tested it in my local. Let me know if I need to add something else.